### PR TITLE
IndexedDB と fetch と registerFileBuffer を利用する

### DIFF
--- a/src/main.mts
+++ b/src/main.mts
@@ -1,19 +1,6 @@
 import * as duckdb from '@duckdb/duckdb-wasm'
-import eh_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url'
-import mvp_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url'
-import duckdb_wasm_eh from '@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url'
-import duckdb_wasm from '@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url'
-
-const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
-  mvp: {
-    mainModule: duckdb_wasm,
-    mainWorker: mvp_worker,
-  },
-  eh: {
-    mainModule: duckdb_wasm_eh,
-    mainWorker: eh_worker,
-  },
-}
+import duckdb_wasm from '@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url'
+import duckdb_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?worker'
 
 document.addEventListener('DOMContentLoaded', async () => {
   const PARQUET_FILE_URL = import.meta.env.VITE_PARQUET_FILE_URL
@@ -27,11 +14,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (button) button.disabled = true
   }
 
-  const bundle = await duckdb.selectBundle(MANUAL_BUNDLES)
-  const worker = new Worker(bundle.mainWorker ?? '')
+  const worker = new duckdb_worker()
   const logger = new duckdb.ConsoleLogger()
   const db = new duckdb.AsyncDuckDB(logger, worker)
-  await db.instantiate(bundle.mainModule, bundle.pthreadWorker)
+  await db.instantiate(duckdb_wasm)
 
   const conn = await db.connect()
   await conn.query(`

--- a/src/main.mts
+++ b/src/main.mts
@@ -202,6 +202,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       resultElement.innerHTML = ''
     }
 
+    // DuckDBのテーブルを削除
+    const conn = await db.connect()
+    await conn.query('DROP TABLE IF EXISTS rtc_stats;')
+    await conn.close()
+
     await db.dropFile('rtc_stats.parquet')
 
     // IndexedDBからファイルを削除
@@ -220,6 +225,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     const countedElement = document.getElementById('counted')
     if (countedElement) {
       countedElement.textContent = 'カウント: 0'
+    }
+
+    // ボタンの状態を更新
+    if (scanParquetButton) {
+      scanParquetButton.disabled = false
+    }
+    if (samplesButton) {
+      samplesButton.disabled = true
+    }
+    if (aggregationButton) {
+      aggregationButton.disabled = true
     }
   })
 })

--- a/tests/playwright/main.spec.ts
+++ b/tests/playwright/main.spec.ts
@@ -21,12 +21,6 @@ test('scan parquet', async ({ page }) => {
   // テーブルが表示されたことを確認
   await expect(page.locator('#result').locator('table')).toBeVisible()
 
-  // 「Clear」ボタンをクリック
-  await page.click('#clear')
-
-  // テーブルがクリアされたことを確認
-  await expect(page.locator('#result').locator('table')).not.toBeVisible()
-
   // 「Aggregation」ボタンをクリック
   await page.click('#aggregation')
 


### PR DESCRIPTION
This pull request includes several significant changes to the `src/main.mts` file, focusing on simplifying the DuckDB worker setup and adding IndexedDB support for caching Parquet files. Here are the most important changes:

### Simplification of DuckDB Worker Setup:
* Removed manual bundle selection and worker instantiation, replacing it with a direct import and instantiation of `duckdb_worker` and `duckdb_wasm`. (`src/main.mts` [[1]](diffhunk://#diff-5ed8461281c772b389e1961ffbc8507c18bf9af7e241894c19dfb775679f045eL2-R3) [[2]](diffhunk://#diff-5ed8461281c772b389e1961ffbc8507c18bf9af7e241894c19dfb775679f045eL30-R20)

### IndexedDB Integration:
* Implemented functions to save, retrieve, and delete Parquet file buffers from IndexedDB, enhancing performance by caching the files locally. (`src/main.mts` [[1]](diffhunk://#diff-5ed8461281c772b389e1961ffbc8507c18bf9af7e241894c19dfb775679f045eR37-R55) [[2]](diffhunk://#diff-5ed8461281c772b389e1961ffbc8507c18bf9af7e241894c19dfb775679f045eL186-R293)

### Event Listener Enhancements:
* Updated the `DOMContentLoaded` event listener to use the new IndexedDB functions, ensuring that Parquet files are cached and retrieved efficiently. (`src/main.mts` [src/main.mtsR37-R55](diffhunk://#diff-5ed8461281c772b389e1961ffbc8507c18bf9af7e241894c19dfb775679f045eR37-R55))
* Enhanced the 'clear' button event listener to remove the cached Parquet file from IndexedDB and update the UI accordingly. (`src/main.mts` [src/main.mtsL186-R293](diffhunk://#diff-5ed8461281c772b389e1961ffbc8507c18bf9af7e241894c19dfb775679f045eL186-R293))